### PR TITLE
Use Python3 compatible string interpolation for print statement.

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,4 +18,4 @@ message = client.messages \
         from_="+15017122661"
     )
 
-print(f'Message SID: {message.sid}')
+print('Message SID: {}'.format(message.sid))


### PR DESCRIPTION
This print statement throws a syntax error with python3. Updating to use python3-compatible interpolation